### PR TITLE
fix(user-devise): dont check user signed_in in activeadmin

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,4 @@
 class ApplicationController < ActionController::Base
   include Pundit
   protect_from_forgery with: :exception
-  before_action :authenticate_user!
 end

--- a/app/controllers/base_controller.rb
+++ b/app/controllers/base_controller.rb
@@ -1,0 +1,3 @@
+class BaseController < ApplicationController
+  before_action :authenticate_user!
+end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,3 +1,3 @@
-class HomeController < ApplicationController
+class HomeController < BaseController
   def index; end
 end


### PR DESCRIPTION
Actualmente verifica si está logeado como usuario normal al intentar entra a la sección de ActiveAdmin. Se creó un controlador `BaseController` del cuál heredarán los controladores de la aplicación por parte del usuario normal (no admin).