### PR TITLE
fix(admin/campaign-devices): fix devices belongs relation

### DIFF
--- a/app/admin/device.rb
+++ b/app/admin/device.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register Device do
-  belongs_to :campaign, optional: true
+  belongs_to :campaign, optional: true, finder: :find_by_slug
   permit_params :name, :serial, :company_id, :campaign_id
 
   filter :company


### PR DESCRIPTION
En el módulo de admin, al entrar a la vista de dispositivos pertenecientes a una campaña se caía porque ocupaba buscaba la campaña por id ocupando el parámetro slug. Se modificó la relación en `admin/device.rb` para que busque la campaña por slug.