### PR TITLE
fix(): remove redundant text in Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: bundle exec puma -C ./config/puma.rb
-worker: bundle exec sidekiqworker: bundle exec sidekiq
+worker: bundle exec sidekiq


### PR DESCRIPTION
El comando para iniciar los workers estaba duplicado.