### PR TITLE
fix(measures_sync_job): fix measures sync service call

### DIFF
--- a/app/jobs/measures_sync_job.rb
+++ b/app/jobs/measures_sync_job.rb
@@ -2,6 +2,6 @@ class MeasuresSyncJob < ApplicationJob
   queue_as :default
 
   def perform
-    MeasuresSyncService.sync_since_last
+    MeasuresSyncService.new.sync_since_last
   end
 end


### PR DESCRIPTION
Corregido llamada al servicio (faltaba inicializar el servicio).