### PR TITLE
feat(campaigns): add gender filter

### DIFF
--- a/app/commands/es_search_measures.rb
+++ b/app/commands/es_search_measures.rb
@@ -1,5 +1,5 @@
-class EsSearchMeasures < PowerTypes::Command.new(:campaign, location: nil, after_date: nil,
-                                                            before_date: nil)
+class EsSearchMeasures < PowerTypes::Command.new(:campaign,
+  location: nil, after_date: nil, before_date: nil, gender: nil)
   include Elasticsearch::DSL
   ES_SEARCH_SIZE = 10000
   TIME_FORMAT = '%Y-%m-%d'
@@ -21,6 +21,7 @@ class EsSearchMeasures < PowerTypes::Command.new(:campaign, location: nil, after
   def build_must_definition
     query = [{ term: { campaign_id: @campaign.id } }]
     query.push(term: { location_id: @location.id }) if @location.present?
+    query.push(term: { gender: @gender.to_s }) if @gender.present?
     check_date_range(query) if @after_date || @before_date
 
     query

--- a/app/commands/obtain_campaign_stats.rb
+++ b/app/commands/obtain_campaign_stats.rb
@@ -1,8 +1,7 @@
-class ObtainCampaignStats < PowerTypes::Command.new(:campaign, location: nil, date_group: :day,
-                                                               after_date: nil, before_date: nil)
+class ObtainCampaignStats < PowerTypes::Command.new(:campaign,
+  location: nil, date_group: :day, after_date: nil, before_date: nil, gender: nil)
   def perform
-    measures = EsSearchMeasures.for(campaign: @campaign, location: @location,
-                                    after_date: @after_date, before_date: @before_date).records
+    measures = EsSearchMeasures.for(search_params).records
     measures_data = group_measures(measures)
     CampaignStat.new(
       campaign: @campaign,
@@ -30,6 +29,16 @@ class ObtainCampaignStats < PowerTypes::Command.new(:campaign, location: nil, da
 
     {
       contacts: contact_measures.count, total: total_measures.count
+    }
+  end
+
+  def search_params
+    {
+      campaign: @campaign,
+      location: @location,
+      after_date: @after_date,
+      before_date: @before_date,
+      gender: @gender
     }
   end
 end

--- a/app/controllers/campaigns_controller.rb
+++ b/app/controllers/campaigns_controller.rb
@@ -11,10 +11,14 @@ class CampaignsController < BaseController
   end
 
   def show
-    @campaign_stat = ObtainCampaignStats.for(campaign: campaign, location: location,
-                                             date_group: date_group_by,
-                                             after_date: after_date&.to_time,
-                                             before_date: before_date&.to_time)
+    @campaign_stat = ObtainCampaignStats.for(
+      after_date: after_date&.to_time,
+      before_date: before_date&.to_time,
+      campaign: campaign,
+      date_group: date_group_by,
+      gender: gender,
+      location: location
+    )
     @locations = Location.all.select(:id, :name)
   end
 
@@ -44,5 +48,9 @@ class CampaignsController < BaseController
 
   def before_date
     @before_date ||= params[:before]
+  end
+
+  def gender
+    @gender ||= params[:gender]
   end
 end

--- a/app/helpers/campaigns_helper.rb
+++ b/app/helpers/campaigns_helper.rb
@@ -10,4 +10,12 @@ module CampaignsHelper
     "#{I18n.localize(campaign.start_date, format: :long).upcase} -
       #{I18n.localize(campaign.end_date, format: :long).upcase}"
   end
+
+  def gender_types_json
+    gender_json = []
+    Measure::GENDER_TYPES.each do |gender|
+      gender_json.push(id: gender, name: I18n.t('enumerize.gender')[gender])
+    end
+    gender_json.to_json
+  end
 end

--- a/app/javascript/locales/en.js
+++ b/app/javascript/locales/en.js
@@ -14,6 +14,7 @@ export default {
       filters: {
         afterDate: 'After',
         beforeDate: 'Before',
+        gender: 'Gender',
         locations: 'Locations',
       },
     },

--- a/app/javascript/locales/es-CL.js
+++ b/app/javascript/locales/es-CL.js
@@ -33,6 +33,7 @@ export default {
       filters: {
         afterDate: 'Después de',
         beforeDate: 'Antes de',
+        gender: 'Género',
         locations: 'Locales',
       },
     },

--- a/app/models/measure.rb
+++ b/app/models/measure.rb
@@ -28,7 +28,7 @@ class Measure < ApplicationRecord
 
   validates_numericality_of :happiness, greater_than_or_equal_to: 0, less_than_or_equal_to: 1
 
-  GENDER_TYPES = %i(undefined male female)
+  ::GENDER_TYPES = %i(undefined male female)
   enumerize :gender, in: GENDER_TYPES, default: :undefined
 
   validates_presence_of :measured_at, :w_id, :gender

--- a/app/views/campaigns/_details_campaign_filters.html.erb
+++ b/app/views/campaigns/_details_campaign_filters.html.erb
@@ -8,4 +8,7 @@
   <div class="campaign-details__filter">
     <datetime-picker initial-value="<%= @before_date %>" query-param="before" :placeholder="$t('messages.campaignDetails.filters.beforeDate')"></datetime-picker>
   </div>
+  <div class="campaign-details__filter">
+    <select-filter :options="<%= gender_types_json %>" label="name" initial-selected="<%= @gender %>" track-by="id" query-param="gender" :placeholder="$t('messages.campaignDetails.filters.gender')"></select-filter>
+  </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,6 +30,11 @@
 # available at http://guides.rubyonrails.org/i18n.html.
 
 en:
+  enumerize:
+    gender:
+      male: Male
+      female: Female
+      undefined: Undefined
   messages:
     header:
       logout: Logout

--- a/config/locales/es-CL.yml
+++ b/config/locales/es-CL.yml
@@ -119,6 +119,10 @@ es-CL:
       traditional: Tradicional
       supermarket: Supermercado
       local_consumption: Consumo Local
+    gender:
+      male: Masculino
+      female: Femenino
+      undefined: Indefinido
   messages:
     header:
       logout: Cerrar Sesión

--- a/spec/commands/es_search_measures_spec.rb
+++ b/spec/commands/es_search_measures_spec.rb
@@ -48,7 +48,7 @@ describe EsSearchMeasures do
           .push(range: { measured_at: { gte: after_date.strftime('%Y-%m-%d') } })
       end
 
-      it 'filters by location id' do
+      it 'filters measured_at by after date' do
         expect(Measure).to receive(:es_search).with(es_search_params).and_return(nil)
         perform(campaign: campaign, after_date: after_date)
       end
@@ -62,9 +62,22 @@ describe EsSearchMeasures do
           .push(range: { measured_at: { lte: before_date.strftime('%Y-%m-%d') } })
       end
 
-      it 'filters by location id' do
+      it 'filters measured_at by before date' do
         expect(Measure).to receive(:es_search).with(es_search_params).and_return(nil)
         perform(campaign: campaign, before_date: before_date)
+      end
+    end
+
+    context 'with gender params' do
+      let(:gender) { 'male' }
+
+      before do
+        es_search_params[:query][:bool][:must].push(term: { gender: gender })
+      end
+
+      it 'filters by gender' do
+        expect(Measure).to receive(:es_search).with(es_search_params).and_return(nil)
+        perform(campaign: campaign, gender: gender)
       end
     end
   end


### PR DESCRIPTION
Se agregó el filtro de género a las estadísticas de una campaña.

![image](https://user-images.githubusercontent.com/2238663/42655680-d05d1f76-85ea-11e8-994b-8a1738372d9d.png)

## Cambios

- Se agregó el select del filtro a la vista de una campaña.
- Se agregó a la consulta de ElasticSearch el filtrar por género.