### PR TITLE
fix(): add time zone to calculate time zone

### DIFF
--- a/app/commands/calculate_units_rotated.rb
+++ b/app/commands/calculate_units_rotated.rb
@@ -32,18 +32,21 @@ class CalculateUnitsRotated < PowerTypes::Command.new(:campaign,
   end
 
   def build_aggs_definitions
-    {
+    aggs = {
       units_rotated_sum: { sum: { field: :items_count } },
       units_rotated: {
         date_histogram: {
           field: :measured_at,
           interval: @date_group,
-          time_zone: "#{Time.now.getlocal.zone}:00",
           min_doc_count: 1
         },
         aggs: { items_by_date: { sum: { field: :items_count } } }
       }
     }
+    if Time.now.getlocal.zone != 'UTC'
+      aggs[:units_rotated][:date_histogram][:time_zone] = "#{Time.now.getlocal.zone}:00"
+    end
+    aggs
   end
 
   def check_date_range


### PR DESCRIPTION
Cuándo está en Heroku `Time.now.getlocal.zone` toma valor `UTC`, lo que hace que se caiga al enviar `UTC:00` al servidor de ES. Como por defecto el valor de `time_zone` es "00:00" (que es lo mismo que UTC),  se agrega una condicional para setear el `time_zone` en la query a ES.