### PR TITLE
fix(weight_measures_sync): complete sync with empty results

### DIFF
--- a/app/services/weight_measures_sync_service.rb
+++ b/app/services/weight_measures_sync_service.rb
@@ -12,11 +12,12 @@ class WeightMeasuresSyncService < PowerTypes::Service.new
     @sync = WeightMeasuresSync.create!(from_date: from_date, to_date: to_date)
     @sync.execute
     w_measures = FetchWeightMeasures.for(from: from_date, to: to_date)
-    return if w_measures.empty?
-    measures = w_measures.group_by { |ms| ms[:device_id] }
-    measures.each do |dev_serial, dev_measures|
-      device = Device.find_or_create_by!(serial: dev_serial)
-      import_measures(device, dev_measures)
+    unless w_measures.empty?
+      measures = w_measures.group_by { |ms| ms[:device_id] }
+      measures.each do |dev_serial, dev_measures|
+        device = Device.find_or_create_by!(serial: dev_serial)
+        import_measures(device, dev_measures)
+      end
     end
     @sync.complete
   end

--- a/spec/services/weight_measures_sync_service_spec.rb
+++ b/spec/services/weight_measures_sync_service_spec.rb
@@ -73,5 +73,18 @@ describe WeightMeasuresSyncService do
     it 'creates measures correctly' do
       expect { perform }.to change { WeightMeasure.count }.by(2)
     end
+
+    context 'when wolke results is empty' do
+      let(:wolke_result) { [] }
+
+      it "doesn't creates new measures " do
+        expect { perform }.not_to(change { WeightMeasure.count })
+      end
+
+      it 'creates a complete synchronization' do
+        expect { perform }.to(change { WeightMeasuresSync.count })
+        expect(WeightMeasuresSync.last.state).to eq(:completed)
+      end
+    end
   end
 end


### PR DESCRIPTION
Al igual que en #41, en las mediciones de peso no se marcaba como completa la sincronización cuando el resultado de la consulta a la API de Wolke retornaba vacío.

## Cambios

- Se cambió el retorno de `sync_measures` por una condicional `unless`.
- Se agregaron dos test para probar que se cree una sincronización completa al recibir un arreglo vacío.