### PR TITLE
feat(device): activate or deactivate devices as admin

### DIFF
--- a/app/admin/device.rb
+++ b/app/admin/device.rb
@@ -1,6 +1,6 @@
 ActiveAdmin.register Device do
   belongs_to :campaign, optional: true, finder: :find_by_slug
-  permit_params :name, :serial, :campaign_id, :location_id
+  permit_params :name, :serial, :campaign_id, :location_id, :active
 
   filter :campaign
   filter :location
@@ -15,6 +15,7 @@ ActiveAdmin.register Device do
     column :campaign
     column :location
     column :created_at
+    toggle_bool_column :active
     actions
   end
 

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -25,6 +25,7 @@ end
 #  updated_at  :datetime         not null
 #  campaign_id :bigint(8)
 #  location_id :bigint(8)
+#  active      :boolean          default(FALSE)
 #
 # Indexes
 #

--- a/config/locales/es-CL.yml
+++ b/config/locales/es-CL.yml
@@ -84,6 +84,7 @@ es-CL:
         campaign: Campaña
         company: Empresa
         location: Local
+        active: Activo
       location:
         <<: *common
         brand: Cadena

--- a/db/migrate/20180816202620_add_column_active_to_device.rb
+++ b/db/migrate/20180816202620_add_column_active_to_device.rb
@@ -1,0 +1,5 @@
+class AddColumnActiveToDevice < ActiveRecord::Migration[5.1]
+  def change
+    add_column :devices, :active, :boolean,  default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180621173835) do
+ActiveRecord::Schema.define(version: 20180816202620) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -85,6 +85,7 @@ ActiveRecord::Schema.define(version: 20180621173835) do
     t.datetime "updated_at", null: false
     t.bigint "campaign_id"
     t.bigint "location_id"
+    t.boolean "active", default: false
     t.index ["campaign_id"], name: "index_devices_on_campaign_id"
     t.index ["location_id"], name: "index_devices_on_location_id"
   end


### PR DESCRIPTION
Se permite al admin activar/desactivar dispositivos desde su índice.

## Cambios

- Se agregó columna `active` a modelo `Device`
- Se agregó toggle de `active` a las entradas del índice de dispositivos en la vista del admin