### PR TITLE
fix(calculate_measures_stats): use correct date range

### DIFF
--- a/app/commands/calculate_measures_stats.rb
+++ b/app/commands/calculate_measures_stats.rb
@@ -22,7 +22,7 @@ class CalculateMeasuresStats < PowerTypes::Command.new(:campaign,
     query = [{ term: { campaign_id: @campaign.id } }]
     query.push(term: { location_id: @location.id }) if @location.present?
     query.push(term: { gender: @gender.to_s }) if @gender.present?
-    query.push(range: { measured_at: date_range_query }) if @after_date || @before_date
+    query.push(range: { measured_at: check_date_range }) if @after_date || @before_date
     query
   end
 
@@ -68,11 +68,5 @@ class CalculateMeasuresStats < PowerTypes::Command.new(:campaign,
     range_query[:lte] = @before_date.localtime.strftime(TIME_FORMAT) if @before_date.present?
     range_query[:gte] = @after_date.localtime.strftime(TIME_FORMAT) if @after_date.present?
     range_query
-  end
-
-  def parse_count_data(results)
-    results.reduce(Hash.new) do |hash, unit_rotated|
-      hash.merge(unit_rotated.key_as_string => unit_rotated.items_by_date.value.to_i)
-    end
   end
 end


### PR DESCRIPTION
Se cambió el rango de fechas para obtener el valor correcto.

## Cambios

- Se usa `check_date_range` para el rango, reemplazando a `date_range_query` que no estaba definida para esta clase
- Se borró método `parse_count_data` ya que no se estaba usando