### PR TITLE
feat(measure): don't consider measures and weight measures from deact…

### DIFF
--- a/app/commands/calculate_measures_stats.rb
+++ b/app/commands/calculate_measures_stats.rb
@@ -19,7 +19,7 @@ class CalculateMeasuresStats < PowerTypes::Command.new(:campaign,
   end
 
   def build_must_definition
-    query = [{ term: { campaign_id: @campaign.id } }]
+    query = [{ term: { campaign_id: @campaign.id } }, { term: { device_active: true } }]
     query.push(term: { location_id: @location.id }) if @location.present?
     query.push(term: { gender: @gender.to_s }) if @gender.present?
     query.push(range: { measured_at: check_date_range }) if @after_date || @before_date

--- a/app/commands/calculate_units_rotated.rb
+++ b/app/commands/calculate_units_rotated.rb
@@ -19,9 +19,12 @@ class CalculateUnitsRotated < PowerTypes::Command.new(:campaign,
   end
 
   def build_must_definition
-    query = [{ term: { campaign_id: @campaign.id } }]
+    query = [
+      { term: { campaign_id: @campaign.id } },
+      { term: { device_active: true } },
+      { range: { items_count: { gt: 0 } } }
+    ]
     query.push(term: { location_id: @location.id }) if @location.present?
-    query.push(range: { items_count: { gt: 0 } })
     query.push(range: { measured_at: date_range_query }) if @after_date || @before_date
     query
   end

--- a/app/models/concerns/elastic/measure_index.rb
+++ b/app/models/concerns/elastic/measure_index.rb
@@ -12,6 +12,7 @@ module Elastic
         mappings do
           indexes :device_name, type: 'text'
           indexes :device_serial, type: 'text'
+          indexes :device_active, type: 'boolean'
           indexes :campaign_name, type: 'text'
           indexes :company_name, type: 'text'
           indexes :location_name, type: 'text'
@@ -26,9 +27,9 @@ module Elastic
       end
 
       def as_indexed_json(_options = {})
-        as_json(methods: [:device_name, :device_serial, :campaign_name, :company_name,
-                          :location_name, :brand_name, :measured_at, :avg_age, :presence_duration,
-                          :contact_duration, :happiness, :gender])
+        as_json(methods: [:device_name, :device_serial, :device_active, :campaign_name,
+                          :company_name, :location_name, :brand_name, :measured_at, :avg_age,
+                          :presence_duration, :contact_duration, :happiness, :gender])
       end
     end
   end

--- a/app/models/concerns/elastic/weight_measure_index.rb
+++ b/app/models/concerns/elastic/weight_measure_index.rb
@@ -12,6 +12,7 @@ module Elastic
         mappings do
           indexes :device_name, type: 'text'
           indexes :device_serial, type: 'text'
+          indexes :device_active, type: 'boolean'
           indexes :campaign_name, type: 'text'
           indexes :company_name, type: 'text'
           indexes :location_name, type: 'text'
@@ -26,9 +27,9 @@ module Elastic
       end
 
       def as_indexed_json(_options = {})
-        as_json(methods: [:device_name, :device_serial, :campaign_name, :company_name,
-                          :location_name, :brand_name, :measured_at, :item_weight, :shelf_weight,
-                          :current_weight, :previous_weight, :items_count])
+        as_json(methods: [:device_name, :device_serial, :device_active, :campaign_name,
+                          :company_name, :location_name, :brand_name, :measured_at, :item_weight,
+                          :shelf_weight, :current_weight, :previous_weight, :items_count])
       end
     end
   end

--- a/app/models/measure.rb
+++ b/app/models/measure.rb
@@ -33,7 +33,7 @@ class Measure < ApplicationRecord
 
   validates_presence_of :measured_at, :w_id, :gender
 
-  delegate :name, :serial, to: :device, allow_nil: true, prefix: true
+  delegate :name, :serial, :active, to: :device, allow_nil: true, prefix: true
   delegate :brand_name, :campaign_name, :company_name, :location_name,
     to: :device, allow_nil: true, prefix: false
 

--- a/app/models/weight_measure.rb
+++ b/app/models/weight_measure.rb
@@ -28,7 +28,7 @@ class WeightMeasure < ApplicationRecord
 
   validates_presence_of :measured_at
 
-  delegate :name, :serial, to: :device, allow_nil: true, prefix: true
+  delegate :name, :serial, :active, to: :device, allow_nil: true, prefix: true
   delegate :brand_name, :campaign_name, :company_name, :location_name,
     to: :device, allow_nil: true, prefix: false
 

--- a/spec/models/measure_spec.rb
+++ b/spec/models/measure_spec.rb
@@ -45,6 +45,10 @@ RSpec.describe Measure, type: :model do
       expect(subject.device_serial).to eq(subject.device.serial)
     end
 
+    it 'device_active' do
+      expect(subject.device_active).to eq(subject.device.active)
+    end
+
     it 'location_name' do
       expect(subject.location_name).to eq(subject.device.location.name)
     end

--- a/spec/models/weight_measure_spec.rb
+++ b/spec/models/weight_measure_spec.rb
@@ -39,6 +39,10 @@ RSpec.describe WeightMeasure, type: :model do
       expect(subject.device_serial).to eq(subject.device.serial)
     end
 
+    it 'device_active' do
+      expect(subject.device_active).to eq(subject.device.active)
+    end
+
     it 'location_name' do
       expect(subject.location_name).to eq(subject.device.location.name)
     end


### PR DESCRIPTION
…ivated devices.

No se consideran las medidas que provienen de dispositivos desactivados.

## Cambios

- Agregado el atributo `active` de `Device` como `delegate` de `Measure` y `WeightMeasure`. Se incluyó el test correspondiente
- Agregado `device_active` al índice de `Measure` y `WeightMeasure`
- Agregada condición al `must` en las queries para obtener estadísticas de `Measure` y `WeightMeasure`
