### PR TITLE
feat(campaing-index): add all stats to index view summary

### DIFF
--- a/app/controllers/campaigns_controller.rb
+++ b/app/controllers/campaigns_controller.rb
@@ -2,11 +2,7 @@ class CampaignsController < BaseController
   def index
     @stats = {}
     current_user.company.campaigns.each do |campaign|
-      stats = ObtainCampaignStats.for(campaign: campaign)
-      @stats[campaign.id] = {
-        total_views: stats.contacts_sum,
-        total_people: stats.total_sum
-      }
+      @stats[campaign.id] = ObtainCampaignStats.for(campaign: campaign)
     end
   end
 

--- a/app/helpers/campaigns_helper.rb
+++ b/app/helpers/campaigns_helper.rb
@@ -1,9 +1,9 @@
 module CampaignsHelper
   def campaign_graph_data(campaign_data)
     [
-      { name: I18n.t('messages.campaigns.total_people'), data: campaign_data.total_data },
+      { name: I18n.t('messages.campaigns.people'), data: campaign_data.total_data },
       { name: I18n.t('messages.campaigns.contacts'), data: contacts_data_extended(campaign_data) },
-      { name: I18n.t('messages.campaigns.units_rotated'), data: campaign_data.units_rotated_data }
+      { name: I18n.t('messages.campaigns.rotated'), data: campaign_data.units_rotated_data }
     ]
   end
 
@@ -46,7 +46,7 @@ module CampaignsHelper
   def summary_stats_elements(stat)
     summary_people_stats(stat).concat(
       [
-        { icon: 'rotation.svg', value: stat.units_rotated_sum, translation: 'unitsRotated',
+        { icon: 'rotation.svg', value: stat.units_rotated_sum, translation: 'rotated',
           class: 'units-rotated' },
         { icon: 'rotation.svg', value: "#{stat.effectiveness}%", translation: 'effectiveness',
           female_value: "#{stat.female_effectiveness}%",
@@ -54,7 +54,7 @@ module CampaignsHelper
         { icon: 'rotation.svg', value: "#{stat.total_happiness}%", translation: 'happiness',
           female_value: "#{stat.total_female_happiness}%",
           male_value: "#{stat.total_male_happiness}%" },
-        { icon: 'rotation.svg', value: stat.total_avg_age, translation: 'avgAge',
+        { icon: 'rotation.svg', value: stat.total_avg_age, translation: 'age',
           female_value: stat.total_female_avg_age, male_value: stat.total_male_avg_age }
       ]
     )
@@ -64,7 +64,7 @@ module CampaignsHelper
     [
       { icon: 'contacts.svg', value: stat.contacts_sum, translation: 'contacts',
         female_value: stat.contacts_female_sum, male_value: stat.contacts_male_sum },
-      { icon: 'seen.svg', value: stat.total_sum, translation: 'totalPeople',
+      { icon: 'seen.svg', value: stat.total_sum, translation: 'people',
         female_value: stat.total_female_sum, male_value: stat.total_male_sum,
         class: 'total-people' }
     ]

--- a/app/javascript/locales/en.js
+++ b/app/javascript/locales/en.js
@@ -24,11 +24,11 @@ export default {
       },
       stats: {
         contacts: 'Contacts',
-        totalPeople: 'Flow of people',
-        unitsRotated: 'Units rotated',
+        people: 'Flow of people',
+        rotated: 'Units rotated',
         effectiveness: 'Effectiveness',
         happiness: 'Happiness',
-        avgAge: 'Avg. Age',
+        age: 'Avg. Age',
       },
     },
     errors: {

--- a/app/javascript/locales/es-CL.js
+++ b/app/javascript/locales/es-CL.js
@@ -43,11 +43,11 @@ export default {
       },
       stats: {
         contacts: 'Contactos',
-        totalPeople: 'Personas',
-        unitsRotated: 'Unid. rotaron',
+        people: 'Personas',
+        rotated: 'Unid. rotaron',
         effectiveness: 'De Efectividad',
         happiness: 'De Felicidad',
-        avgAge: 'Edad. Prom',
+        age: 'Edad. Prom',
       },
     },
     errors: {

--- a/app/views/campaigns/_campaign_summary.html.erb
+++ b/app/views/campaigns/_campaign_summary.html.erb
@@ -4,19 +4,14 @@
     <%= campaign_date_range(campaign) %>
   </h5>
   <div class="campaign-option__stats-container">
-    <div class="campaign-stat campaign-option__stat">
-      <%= image_tag 'contacts.svg', class: 'campaign-stat__icon' %>
-      <div class="campaign-stat__content">
-        <span class="campaign-stat__value"><%= stats[:total_views] %></span>
-        <span class="campaign-stat__label"><%= t('messages.campaigns.contacts') %></span>
+    <% summary_stats_elements(stats).each do |element| %>
+      <div class="campaign-stat campaign-option__stat">
+        <%= image_tag element[:icon], class: 'campaign-stat__icon' %>
+        <div class="campaign-stat__content">
+          <span class="campaign-stat__value"><%= element[:value] %></span>
+          <span class="campaign-stat__label"><%= t("messages.campaigns.#{element[:translation]}") %></span>
+        </div>
       </div>
-    </div>
-    <div class="campaign-stat campaign-option__stat">
-      <%= image_tag 'seen.svg', class: 'campaign-stat__icon' %>
-      <div class="campaign-stat__content">
-        <span class="campaign-stat__value"><%= stats[:total_people] %></span>
-        <span class="campaign-stat__label"><%= t('messages.campaigns.total_people') %></span>
-      </div>
-    </div>
+    <% end %>
   </div>
 </a>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -48,8 +48,11 @@ en:
       index:
         title: Campaign
       contacts: Contacts
-      units_rotated: Units rotated
-      total_people: People Flow
+      people: Flow of people
+      rotated: Units rotated
+      effectiveness: Effectiveness
+      happiness: Happiness
+      age: Avg. Age
       week: Week from
     campaign_dashboard:
       details_title: Details

--- a/config/locales/es-CL.yml
+++ b/config/locales/es-CL.yml
@@ -137,8 +137,11 @@ es-CL:
       index:
         title: Campañas
       contacts: Contactos
-      units_rotated: Unidades rotaron
-      total_people: Flujo de gente
+      people: Personas
+      rotated: Unid. rotaron
+      effectiveness: De Efectividad
+      happiness: De Felicidad
+      age: Edad. Prom
       week: Semana desde
     campaign_dashboard:
       details_title: Detalles


### PR DESCRIPTION
Se agregaron todas las estadística en el resumen de cada compañía en el _index_.
![screen shot 2018-09-06 at 12 32 18 pm](https://user-images.githubusercontent.com/12057523/45168117-efd7a080-b1d0-11e8-8a29-31355add9879.png)

## Cambios 
- Se generalizó la manera en que se muestran las estadísticas en `_campaign_summary.html.erb`, ahora se usa el arreglo entregado por summary_stats_elements para las estadísticas de cada empresa
- En las traducciones, se cambio total_people, units_rotated y avg_age por nombres con una sola palabra, ya que se usan tanto en js como en ruby, para no tener problemas con la diferencia en convenciones
- Se agregaron las traducciones para las estadísticas en el _index_