### PR TITLE
feat(admin-measures): add button to upload csv with measures

### DIFF
--- a/app/admin/measure.rb
+++ b/app/admin/measure.rb
@@ -2,6 +2,52 @@ ActiveAdmin.register Measure do
   permit_params :device_id, :measured_at, :avg_age, :w_id, :presence_duration, :contact_duration,
     :happiness, :gender
 
+  controller do
+    def upload_csv
+      if params[:csv].nil?
+        fail_upload(t("active_admin.measures.upload.empty"))
+      elsif !params[:csv].original_filename.end_with? ".csv"
+        fail_upload(t("active_admin.measures.upload.extension_error"))
+      else
+        save_measures(CSV.parse(params[:csv].read))
+        redirect_to admin_measures_path, notice: t("active_admin.measures.upload.success")
+      end
+    rescue ActiveRecord::RecordInvalid
+      fail_upload(t("active_admin.measures.upload.format_error"))
+    rescue
+      fail_upload(t("active_admin.measures.upload.general_error"))
+    end
+
+    private
+
+    def fail_upload(alert)
+      redirect_to admin_measures_path, alert: alert
+    end
+
+    def save_measures(csv_data)
+      csv_data[1..-1].each do |row|
+        Measure.create!(
+          device_id: row[0],
+          measured_at: row[1],
+          avg_age: row[2],
+          w_id: row[3],
+          presence_duration: row[4],
+          contact_duration: row[5],
+          happiness: row[6],
+          gender: row[7]
+        )
+      end
+    end
+  end
+
+  collection_action :upload, method: :get do
+    @page_title = t("active_admin.measures.upload.title")
+  end
+
+  action_item :upload, only: :index do
+    link_to t("active_admin.measures.upload.button"), upload_admin_measures_path
+  end
+
   filter :device
   filter :campaign
   filter :campaign_company_id, as: :select, collection: -> { Company.all }

--- a/app/views/admin/measures/upload.html.erb
+++ b/app/views/admin/measures/upload.html.erb
@@ -1,0 +1,4 @@
+<%= form_tag({ action: :upload_csv }, multipart: true) do %>
+  <%= file_field_tag 'csv' %>
+  <%= submit_tag 'send' %>
+<% end %>

--- a/config/locales/active_admin/en.yml
+++ b/config/locales/active_admin/en.yml
@@ -1,5 +1,14 @@
 en:
   active_admin:
+    measures:
+      upload:
+        button: Upload CSV
+        title: Upload Measures
+        empty: Empty CSV
+        extension_error: Not a .csv
+        success: Measures created
+        format_error: Error in CSV data format
+        general_error: An error ocurred
     devices:
       zero: Unasigned
       one: 1 Device

--- a/config/locales/active_admin/es-CL.yml
+++ b/config/locales/active_admin/es-CL.yml
@@ -1,5 +1,14 @@
 es-CL:
   active_admin:
+    measures:
+      upload:
+        button: Subir CSV
+        title: Subir Mediciones
+        empty: CSV vacío
+        extension_error: No es un .csv
+        success: Mediciones creadas
+        format_error: Error de formato en la data del CSV
+        general_error: Ocurrió un error
     devices:
       zero: Sin Disp.
       one: 1 Disp.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
     end
   end
   devise_for :admin_users, ActiveAdmin::Devise.config
+  post '/admin/measures/upload_csv', to: 'admin/measures#upload_csv'
   ActiveAdmin.routes(self)
   devise_for :users
   mount Sidekiq::Web => '/queue'


### PR DESCRIPTION
Se agregó un botón en la vista de mediciones del admin para agregar mediciones masivamente mediante un csv.

## Cambios

- Se agregó un `action_item` que renderea un botón en la parte superior para ir a subir un archivo
- Este botón redirige, gracias a una nueva `collection_action` a un template que contiene un `form` con solo un `file_field_tag` y el `submit`
- Al mandar el formulario, se llama a el nuevo método `upload_csv` que realiza chequeos previo a guardar las nuevas mediciones
- Se crearon métodos privados para extraer lógica de `upload_csv` y disminuir su complejidad