### PR TITLE
fix(campaign-details): change path of images to be set in erb

### DIFF
--- a/app/javascript/tools/stat.vue
+++ b/app/javascript/tools/stat.vue
@@ -3,7 +3,7 @@
     <div class="campaign-detail-data">
       <div @click="toggleShow" :class="statClass">
         <div class="campaign-detail-data__icon">
-          <img :src="icon">
+          <img :src="image">
         </div>
         <div class="campaign-detail-data__data-container">
           <span :class="valueClass">{{ value }}</span>
@@ -21,7 +21,7 @@
 import { mixin as clickaway } from 'vue-clickaway';
 
 export default {
-  props: ['element'],
+  props: ['element', 'image'],
   mixins: [clickaway],
   data() {
     const elementParsed = JSON.parse(this.element);
@@ -31,7 +31,6 @@ export default {
       '';
 
     return {
-      icon: `/assets/${elementParsed.icon}`,
       valueClass: `campaign-detail-data__data ${optionalValuesClass}`,
       statClass: `campaign-detail-data__icon-data-container ${optionalDataClass}`,
       value: elementParsed.value,

--- a/app/views/campaigns/_details_summary_stats.html.erb
+++ b/app/views/campaigns/_details_summary_stats.html.erb
@@ -1,5 +1,5 @@
 <div class="campaign-details__summary">
   <% summary_stats_elements(@campaign_stat).each do |element| %>
-    <stat element="<%= element.to_json %>"></stat>
+    <stat element="<%= element.to_json %>" image="<%= image_path(element[:icon]) %>"></stat>
   <% end %>
 </div>


### PR DESCRIPTION
Se usa el helper image_path para entregar los íconos a la vista de una campaña, ya que de la forma anterior, en el ambiente de staging en heroku no se veían las imágenes