### PR TITLE
fix(logos): use image tag height to resize images

### DIFF
--- a/app/admin/campaign.rb
+++ b/app/admin/campaign.rb
@@ -58,11 +58,7 @@ ActiveAdmin.register Campaign do
       row :created_at
       row :logo do |campaign|
         logo = campaign.logo
-        if logo.attached? && logo.variable?
-          image_tag logo.variant(resize: '100x100')
-        elsif logo.attached?
-          image_tag(logo, size: '100x100')
-        end
+        image_tag(logo, class: 'campaign__logo') if logo.attached?
       end
     end
   end

--- a/app/admin/company.rb
+++ b/app/admin/company.rb
@@ -42,11 +42,7 @@ ActiveAdmin.register Company do
       row :created_at
       row :logo do |company|
         logo = company.logo
-        if logo.attached? && logo.variable?
-          image_tag logo.variant(resize: '100x100')
-        elsif logo.attached?
-          image_tag(logo, size: '100x100')
-        end
+        image_tag(logo, class: 'company__logo') if logo.attached?
       end
     end
   end

--- a/app/assets/stylesheets/active_admin.scss
+++ b/app/assets/stylesheets/active_admin.scss
@@ -31,3 +31,15 @@ $panelHeaderBck: #002744;
   }
 }
 
+.campaign {
+  &__logo {
+    height: 100px;
+  }
+}
+
+.company {
+  &__logo {
+    height: 100px;
+  }
+}
+

--- a/app/assets/stylesheets/app/app.scss
+++ b/app/assets/stylesheets/app/app.scss
@@ -76,6 +76,10 @@
     letter-spacing: $app-spacing-letter;
   }
 
+  &__company-logo {
+    height: 60px;
+  }
+
   &__campaign-container {
     display: contents;
   }
@@ -83,8 +87,13 @@
   &__campaign-name {
     color: $header-name-color;
     font-family: $main-font;
-    letter-spacing: $app-spacing-letter;
     font-size: 24px;
+    letter-spacing: $app-spacing-letter;
     line-height: 29px;
+    padding-right: 5px;
+  }
+
+  &__campaign-logo {
+    height: 60px;
   }
 }

--- a/app/assets/stylesheets/app/campaigns.scss
+++ b/app/assets/stylesheets/app/campaigns.scss
@@ -26,6 +26,7 @@
   }
 
   &__logo {
+    height: 50px;
     vertical-align: bottom;
   }
 

--- a/app/views/campaigns/_campaign_summary.html.erb
+++ b/app/views/campaigns/_campaign_summary.html.erb
@@ -1,7 +1,7 @@
 <a href="<%= campaign_path(campaign) %>" class="campaign-option" >
   <h2 class="campaign-option__title">
     <%= campaign.name %>
-    <%= image_tag campaign.logo.variant(resize: '50x50'), class: 'campaign-option__logo' if campaign.logo.attached? %>
+    <%= image_tag(campaign.logo, class: 'campaign-option__logo') if campaign.logo.attached? %>
   </h2>
   <h5 class="campaign-option__date-range">
     <%= campaign_date_range(campaign) %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -8,13 +8,13 @@
         <p class="header__campaign-name">
           <%= @campaign.name %>
         </p>
-        <%= image_tag @campaign.logo.variant(resize: '60x60') if @campaign.logo.attached? %>
+        <%= image_tag(@campaign.logo, class: 'header__campaign-logo') if @campaign.logo.attached? %>
       </div>
     <% end %>
     <div class="header__menu-section">
       <p class="header__company-name">
         <% if current_user&.company.logo.attached? %>
-          <%= image_tag current_user&.company.logo.variant(resize: '60x60') %>
+          <%= image_tag(current_user&.company.logo, class: 'header__company-logo') %>
         <% else %>
           <%= current_user&.company.name %>
         <% end %>


### PR DESCRIPTION
## Cambios
- Antes se usaba `.variant` en los logos para cambiar su tamaño, pero eso no funciona con archivos `.svg`. Se cambió y ahora se setea el height directamente en el image_tag, así se mantienen las proporciones de la imágen y funciona también para formatos vectoriales. En las imágenes siguientes, el logo verde es un `.svg`
![screen shot 2018-09-12 at 10 29 44 am](https://user-images.githubusercontent.com/12057523/45428104-e047d400-b676-11e8-8a2e-d10a61718b08.png)
![screen shot 2018-09-12 at 10 30 06 am](https://user-images.githubusercontent.com/12057523/45428105-e047d400-b676-11e8-89ad-c9dc542e2342.png)

- Además, se agregó un padding en el título de la campaña para separarlo de la imágen.
