### PR TITLE
chore(buildpacks): move deploy tasks to release phase

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,4 +1,3 @@
 https://github.com/heroku/heroku-buildpack-nodejs
 https://github.com/platanus/heroku-buildpack-ruby-version.git
 https://github.com/heroku/heroku-buildpack-ruby.git
-https://github.com/gunpowderlabs/buildpack-ruby-rake-deploy-tasks.git

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
 web: bundle exec puma -C ./config/puma.rb
 worker: bundle exec sidekiq
+release: bin/release

--- a/bin/release
+++ b/bin/release
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+echo 'Release Phase...'
+
+bundle exec rake db:migrate
+
+echo 'Release Phase: OK'


### PR DESCRIPTION
### Cambios
- Se removió el buildpack de `deploy-tasks` que sacaba las tasks de la variable de entorno `DEPLOY_TASKS`
- Se movieron las migraciones a un archivo `release`, que se llama en `release` desde el Procfile
![screen shot 2018-09-26 at 5 19 02 pm](https://user-images.githubusercontent.com/12057523/46107189-1a55c180-c1b1-11e8-87bf-12e5b328f06c.png)
