### PR TITLE
fix(weight-measure-sync): add items_max to Wolke sync

### DIFF
--- a/app/services/weight_measures_sync_service.rb
+++ b/app/services/weight_measures_sync_service.rb
@@ -38,6 +38,7 @@ class WeightMeasuresSyncService < PowerTypes::Service.new
       device.weight_measures.create!(
         measured_at: measure_data[:time].to_time,
         item_weight: measure_data[:item_weight].to_i,
+        items_max: measure_data[:items_max].to_i,
         shelf_weight: measure_data[:shelf_weight].to_i,
         current_weight: measure_data[:current_weight].to_i,
         previous_weight: measure_data[:previous_weight].to_i,

--- a/spec/services/weight_measures_sync_service_spec.rb
+++ b/spec/services/weight_measures_sync_service_spec.rb
@@ -53,9 +53,9 @@ describe WeightMeasuresSyncService do
     let(:wolke_result) do
       [
         { device_id: "1234567890", time: "2018-06-18 15:57:00", item_weight: 10,
-          shelf_weight: 89, current_weight: 550, previous_weight: 540 },
+          items_max: 20, shelf_weight: 89, current_weight: 550, previous_weight: 540 },
         { device_id: "1234567890", time: "2018-06-21 15:59:00", item_weight: 10,
-          shelf_weight: 89, current_weight: 550, previous_weight: 540 }
+          items_max: 20, shelf_weight: 89, current_weight: 550, previous_weight: 540 }
       ]
     end
     let(:perform) { build.sync_measures(from_date: from_date, to_date: to_date) }


### PR DESCRIPTION
Se agrega un nuevo parámetro a la sincronización con los datos que vienen de Wolke: `items_max`.