### PR TITLE
style(campaign): move filters to a sidebar

### DIFF
--- a/app/assets/stylesheets/app/_base.scss
+++ b/app/assets/stylesheets/app/_base.scss
@@ -25,6 +25,7 @@ $app-spacing-letter: .8px;
 
 $app-filter-color: #a0b3b8;
 $app-filter-border: 1px solid rgba(189, 212, 218, .65);
+$app-sidebar-shadow-color: rgba(160, 179, 184, .12);
 $active-filter-color: #00c46c;
 
 @font-face {

--- a/app/assets/stylesheets/app/app.scss
+++ b/app/assets/stylesheets/app/app.scss
@@ -8,13 +8,15 @@
 
 .app {
   background-color: $main-bg-color;
+  display: flex;
+  flex-direction: column;
   min-height: 100vh;
   text-align: center;
 
   &__container {
+    display: flex;
+    flex-grow: 1;
     text-align: left;
-    margin: 0 auto;
-    width: 1024px;
   }
 
   &__title {

--- a/app/assets/stylesheets/app/campaigns.scss
+++ b/app/assets/stylesheets/app/campaigns.scss
@@ -88,25 +88,40 @@
   flex-basis: 100%;
 
   &__title {
+    color: $primary-font-color;
     font-family: $main-font;
     font-weight: bold;
-    color: $primary-font-color;
-    margin: 32px 0 6px;
     line-height: 26px;
+    margin: 25px 0 6px;
+  }
+
+  &__sidebar {
+    background-color: $white;
+    border: $app-content-border;
+    box-shadow: 0 0 18px 0 $app-sidebar-shadow-color;
+    margin-top: 5px;
+    opacity: .88;
+    padding: 0 25px;
+    width: 176px;
+  }
+
+  &__main {
+    padding: 25px 55px;
+    width: calc(100% - 338px);
   }
 
   &__filters-container {
-    display: flex;
-    flex-direction: row;
+    margin-top: 20px;
   }
 
   &__filter {
-    flex-basis: calc((100% - 30px)/4);
-    margin-right: 10px;
+    margin: 10px 0;
   }
 
-  &__filter:last-child {
-    margin-right: 0;
+  &__filter-separator {
+    border: $app-filter-border;
+    margin: 15px 0;
+    opacity: .3;
   }
 
   &__summary {

--- a/app/views/campaigns/_details_campaign_filters.html.erb
+++ b/app/views/campaigns/_details_campaign_filters.html.erb
@@ -8,18 +8,21 @@
   <div class="campaign-details__filter">
     <select-filter :options="<%= @channels.to_json %>" label="name" initial-selected="<%= @channel %>" track-by="id" query-param="channel" :placeholder="$t('messages.campaignDetails.filters.channels')"></select-filter>
   </div>
+  <div class="campaign-details__filter-separator"></div>
   <div class="campaign-details__filter">
     <select-filter :options="<%= @communes.to_json %>" label="name" initial-selected="<%= @commune&.id %>" track-by="id" query-param="commune" :placeholder="$t('messages.campaignDetails.filters.communes')"></select-filter>
   </div>
   <div class="campaign-details__filter">
     <select-filter :options="<%= @regions.to_json %>" label="name" initial-selected="<%= @region&.id %>" track-by="id" query-param="region" :placeholder="$t('messages.campaignDetails.filters.regions')"></select-filter>
   </div>
+  <div class="campaign-details__filter-separator"></div>
   <div class="campaign-details__filter">
     <datetime-picker initial-value="<%= @after_date %>" query-param="after" :placeholder="$t('messages.campaignDetails.filters.afterDate')"></datetime-picker>
   </div>
   <div class="campaign-details__filter">
     <datetime-picker initial-value="<%= @before_date %>" query-param="before" :placeholder="$t('messages.campaignDetails.filters.beforeDate')"></datetime-picker>
   </div>
+  <div class="campaign-details__filter-separator"></div>
   <div class="campaign-details__filter">
     <select-filter :options="<%= gender_types_json %>" label="name" initial-selected="<%= @gender %>" track-by="id" query-param="gender" :placeholder="$t('messages.campaignDetails.filters.gender')"></select-filter>
   </div>

--- a/app/views/campaigns/show.html.erb
+++ b/app/views/campaigns/show.html.erb
@@ -1,16 +1,20 @@
 <div id="app" class="app">
   <%= render 'shared/header' %>
   <div class="campaign-details app__container">
-    <h3 class="campaign-details__title"><%= t('messages.campaign_dashboard.filters_title') %></h3>
-    <%= render 'details_campaign_filters' %>
-    <h3 class="campaign-details__title"><%= t('messages.campaign_dashboard.details_title') %></h3>
-    <%= render 'details_summary_stats' %>
-    <div class="summary-graph campaign-details__graph">
-      <div class="summary-graph__selector">
-        <group-date-selector initial-group="<%= @date_group_by.to_s %>"></group-date-selector>
-      </div>
-      <div class="summary-graph__graph">
-        <chart v-bind:series="<%= campaign_graph_data(@campaign_stat).to_json %>" date_format="<%= date_format(@date_group_by.to_s) %>" ></chart>
+    <div class="campaign-details__sidebar">
+      <h3 class="campaign-details__title"><%= t('messages.campaign_dashboard.filters_title') %></h3>
+      <%= render 'details_campaign_filters' %>
+    </div>
+    <div class="campaign-details__main">
+      <h3 class="campaign-details__title"><%= t('messages.campaign_dashboard.details_title') %></h3>
+      <%= render 'details_summary_stats' %>
+      <div class="summary-graph campaign-details__graph">
+        <div class="summary-graph__selector">
+          <group-date-selector initial-group="<%= @date_group_by.to_s %>"></group-date-selector>
+        </div>
+        <div class="summary-graph__graph">
+          <chart v-bind:series="<%= campaign_graph_data(@campaign_stat).to_json %>" date_format="<%= date_format(@date_group_by.to_s) %>" ></chart>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Se cambio el estilo de los filtros para que estén en un _sidebar_
<img width="960" alt="screen shot 2018-10-09 at 4 54 02 pm" src="https://user-images.githubusercontent.com/12057523/46742414-5abb4200-cc7d-11e8-9ff4-ea50d19f3478.png">

## Cambios
### App.scss
- `.app`: se trata como flexbox
- `.app__container`:  se trata como flexbox y se le agregó `flex-grow: 1` para que tome todo el alto restante de la página

### Campaigns.scss
- Se agregó `.campaign-details__sidebar` que corresponde al área de los filtros. Se posiciona dentro del flexbox de `.app__container` y se le setea el width
- Se agregó `.campaign-details__main` que corresponde al espacio a la derecha de los filtros. Se posiciona dentro del flexbox de `.app__container` y se le setea el width mediante `calc`
- Se agregó `.campaign-details__filter-separator` para agrupar lógicamente los filtros