### PR TITLE
fix(campaigns-style): return view to previous state

### DIFF
--- a/app/assets/stylesheets/app/app.scss
+++ b/app/assets/stylesheets/app/app.scss
@@ -18,12 +18,6 @@
     flex-grow: 1;
     text-align: left;
   }
-
-  &__title {
-    font-family: $main-font;
-    font-weight: bold;
-    color: $primary-font-color;
-  }
 }
 
 .header {

--- a/app/assets/stylesheets/app/campaigns.scss
+++ b/app/assets/stylesheets/app/campaigns.scss
@@ -1,5 +1,16 @@
 @import './base';
 
+.campaigns {
+  margin: 0 auto;
+  width: 1024px;
+
+  &__title {
+    color: $primary-font-color;
+    font-family: $main-font;
+    font-weight: bold;
+  }
+}
+
 .campaign-option {
   display: flex;
   flex-direction: column;

--- a/app/views/campaigns/index.html.erb
+++ b/app/views/campaigns/index.html.erb
@@ -1,9 +1,11 @@
 <div id="app" class="app">
   <%= render 'shared/header' %>
   <div class="app__container">
-    <h2 class="app__title"><%= t('messages.campaigns.index.title') %></h2>
-    <% current_user.company.campaigns.each do |campaign| %>
-      <%= render 'campaign_summary', campaign: campaign, stats: @stats[campaign.id] %>
-    <% end %>
+    <div class="campaigns">
+      <h2 class="campaigns__title"><%= t('messages.campaigns.index.title') %></h2>
+      <% current_user.company.campaigns.each do |campaign| %>
+        <%= render 'campaign_summary', campaign: campaign, stats: @stats[campaign.id] %>
+      <% end %>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
Con el PR #68, se desconfiguro la vista de índice. Para arreglarlo, se agrega un div container para el contenido de esta vista, con clase `campaigns` que setea el `margin` y `width` como se hacía antes.
Además, se movió el estilo de `app__title` a `campaigns__title`, ya que creo que semánticamente hace más sentido