### PR TITLE
fix(chart): show contacts regardless of plot points

### DIFF
--- a/app/javascript/tools/chart.vue
+++ b/app/javascript/tools/chart.vue
@@ -76,6 +76,11 @@ export default {
         legend: false,
         credits: false,
         colors: ['#11b0fc', '#00c46c', '#fe7b4f'],
+        plotOptions: {
+          series: {
+            turboThreshold: 0,
+          },
+        },
         series: this.series,
       },
     };


### PR DESCRIPTION
Se arregla un bug que hacía que no se mostrara el _plot_ correspondiente a los contactos cuando habían demasiados puntos en el gráfico. En particular, se activaba este bug cuando se mostraban las mediciones por hora. 
Para arreglarlo se setea `turboThreshold: 0` en las opciones de la librería `highcharts`. Esta opción corresponde al número de puntos sobre el cual no se muestran los gráficos con información en forma de objeto (más detalle [aquí](https://api.highcharts.com/highcharts/series.line.data)), y el gráfico de Contactos ocupa este formato. Setearlo en 0 es equivalente a que no haya límite de puntos