### PR TITLE
fix(campaign): check if campaign has associated brands or channels

### DIFF
--- a/app/controllers/campaigns_controller.rb
+++ b/app/controllers/campaigns_controller.rb
@@ -43,10 +43,11 @@ class CampaignsController < BaseController
 
     @locations = all_locs.filtered(build_locations_filters_hash)
 
-    @brands = Brand.find(all_locs.pluck(:brand_id).uniq)
+    @brands = Brand.find(all_locs.pluck(:brand_id).compact.uniq) || []
     @channels = all_locs.reduce(Set.new) do |arr, loc|
-      arr.add(name: t("enumerize.channel.#{loc.channel}"), id: loc.channel)
+      arr.add(name: t("enumerize.channel.#{loc.channel}"), id: loc.channel) if loc.channel
     end
+    @channels ||= []
     @regions = Region.find(all_locs.map(&:region_id).uniq)
     @communes = filtered_communes(all_locs)
   end


### PR DESCRIPTION
Si una campaña tenía asociado un `devise` en una `location` que no tenía asociada una `brand`, se caía `Brand.find` ya que se le daba como argumento `[nil]`. Para arreglar esto, se usa `compact` y un `|| []` en caso de ser vacío el arreglo de ids.
Pasaba algo similar con `@channels`