### PR TITLE
Feat/double scale chart

### DIFF
--- a/app/helpers/campaigns_helper.rb
+++ b/app/helpers/campaigns_helper.rb
@@ -3,7 +3,11 @@ module CampaignsHelper
     [
       { name: I18n.t('messages.campaigns.people'), data: campaign_data.total_data },
       { name: I18n.t('messages.campaigns.contacts'), data: contacts_data_extended(campaign_data) },
-      { name: I18n.t('messages.campaigns.extracted'), data: campaign_data.units_extracted_data }
+      {
+        name: I18n.t('messages.campaigns.extracted'),
+        data: campaign_data.units_extracted_data,
+        yAxis: 1
+      }
     ]
   end
 

--- a/app/javascript/locales/en.js
+++ b/app/javascript/locales/en.js
@@ -14,6 +14,8 @@ export default {
     week: 'WEEK',
     day: 'DAY',
     hour: 'HOUR',
+    peopleTitle: 'n˚ of people',
+    unitsTitle: 'n˚ of units',
   },
   messages: {
     campaignDetails: {

--- a/app/javascript/locales/es-CL.js
+++ b/app/javascript/locales/es-CL.js
@@ -27,6 +27,8 @@ export default {
     female: 'Mujeres',
     male: 'Hombres',
     age: 'Edad Promedio',
+    peopleTitle: 'n˚ de personas',
+    unitsTitle: 'n˚ de unidades',
   },
   groupDateSelector: {
     week: 'SEMANA',

--- a/app/javascript/tools/chart.vue
+++ b/app/javascript/tools/chart.vue
@@ -13,12 +13,23 @@ export default {
   },
   data() {
     const that = this;
+    const unitsColor = '#fe7b4f';
 
     return {
       options: {
         title: { text: '' },
         chart: { type: 'spline', zoomType: 'x' },
         xAxis: { type: 'datetime' },
+        yAxis: [
+          { title: { text: this.$i18n.t('graphs.peopleTitle') } },
+          {
+            title: {
+              text: this.$i18n.t('graphs.unitsTitle'),
+              style: { color: unitsColor },
+            },
+            opposite: true,
+          },
+        ],
         tooltip: {
           shared: true,
           useHTML: true,
@@ -75,7 +86,7 @@ export default {
         },
         legend: false,
         credits: false,
-        colors: ['#11b0fc', '#00c46c', '#fe7b4f'],
+        colors: ['#11b0fc', '#00c46c', unitsColor],
         plotOptions: {
           series: {
             turboThreshold: 0,


### PR DESCRIPTION
Se separa el eje Y del gráfico en dos: uno para las unidades extraídas y otro para las personas y contactos.

![image](https://user-images.githubusercontent.com/12057523/48067967-587ed180-e1b0-11e8-8cd3-cf3314ab3926.png)

### Cambios
- A la serie de unidades, se le indica `yAxis: 1` para que ocupe el eje derecho
- Se movieron las traducciones de la _key_ `chart` a `graphs` y se agregaron nuevas traducciones
- Se define en `chart` los dos ejes Y