### PR TITLE
fix(calculate-measures): fix timezone handling

### DIFF
--- a/app/commands/calculate_measures_stats.rb
+++ b/app/commands/calculate_measures_stats.rb
@@ -111,7 +111,7 @@ class CalculateMeasuresStats < PowerTypes::Command.new(:campaign,
       }
     }
     if Time.now.getlocal.zone != 'UTC'
-      agg[:date_histogram][:time_zone] = "#{Time.now.getlocal.zone}:00"
+      agg[:date_histogram][:time_zone] = "America/Santiago"
     end
     agg
   end

--- a/app/commands/calculate_units_stats.rb
+++ b/app/commands/calculate_units_stats.rb
@@ -81,7 +81,7 @@ class CalculateUnitsStats < PowerTypes::Command.new(:campaign,
       }
     }
     if Time.now.getlocal.zone != 'UTC'
-      aggs[:units_extracted][:date_histogram][:time_zone] = "#{Time.now.getlocal.zone}:00"
+      aggs[:units_extracted][:date_histogram][:time_zone] = "America/Santiago"
     end
     aggs.merge(rotation_aggs)
   end


### PR DESCRIPTION
Se cambia la _timezone_ que se envía en la query de ES para que use el nombre de la zona en vez del offset actual. Así se toma en cuenta los días con horario de verano. Como estaba antes, en las zonas de cambio de hora se corrían los días para la vista del gráfico agrupado por días.

**Antes del cambio (notar diferencia entre fecha del eje y del tooltip):**
![screen shot 2018-11-08 at 3 51 17 pm](https://user-images.githubusercontent.com/12057523/48220502-36cb4900-e36e-11e8-81b3-a49324051d7f.png)

**Con el cambio:**
![nov-08-2018 15-43-38](https://user-images.githubusercontent.com/12057523/48220387-e6ec8200-e36d-11e8-97af-8fee80d212b0.gif)

**Valores de días mostrados en la imágen, agrupados por hora:**
![image](https://user-images.githubusercontent.com/12057523/48220548-5febd980-e36e-11e8-9949-d7cd9265e290.png)

