### PR TITLE
feat(devise.scss): make sign-in responsive

### DIFF
--- a/app/assets/stylesheets/app/devise.scss
+++ b/app/assets/stylesheets/app/devise.scss
@@ -5,26 +5,37 @@
   flex-direction: row;
   justify-content: center;
   align-items: center;
-  padding-top: 36px;
+
+  @media only screen and (min-width: #{$mobile-breakpoint}) {
+    padding-top: 36px;
+  }
 
   &__container {
-    width: 446px;
-    height: 494px;
+    align-items: center;
+    background-color: $white;
+    background-image: image-url('login-corner-right.svg');
+    background-position: right bottom;
+    background-repeat: no-repeat;
+    box-sizing: border-box;
     display: flex;
     flex-direction: row;
-    align-items: center;
+    height: calc(100vh - 64px);
     justify-content: center;
-    background-color: $white;
-    background-image: image_url('login-corner-left.svg'), image_url('login-corner-right.svg');
-    background-position: left top, right bottom;
-    background-repeat: no-repeat;
-    border-radius: 5px;
+    padding-bottom: 130px;
+    width: 100%;
+
+    @media only screen and (min-width: #{$mobile-breakpoint}) {
+      background-image: image-url('login-corner-left.svg'), image-url('login-corner-right.svg');
+      background-position: left top, right bottom;
+      border-radius: 5px;
+      height: auto;
+      padding: 130px 0;
+      width: 446px;
+    }
   }
 
   &__form {
-    display: flex;
     width: 70%;
-    flex-direction: column;
   }
 
   &__form-title {


### PR DESCRIPTION
Se modifica el estilo del login para que quede responsive

![nov-21-2018 16-10-03](https://user-images.githubusercontent.com/12057523/48863401-fa550f80-eda7-11e8-88a1-7c1ca232d721.gif)

En dispositivos pequeños:
- Se le quita el `padding-top` al `sign-in`
- `sign-in__container`:
    - Se da un ancho de 100%
    - Se quita la imagen de la esquina superior izquierda
    - Se da un padding-bottom correspondiente a la altura de la imagen de la esquina inferior derecha, para centrar el form sin considerar esa parte y que no se vea tanto espacio en blanco arriba
    - Se calcula la height para que calce con el dispositivo
    - Se quitan bordes redondeados