### PR TITLE
Feat/login inputs opacity

### DIFF
--- a/app/assets/stylesheets/app/devise.scss
+++ b/app/assets/stylesheets/app/devise.scss
@@ -11,7 +11,6 @@
   }
 
   &__container {
-    align-items: center;
     background-color: $white;
     background-image: image-url('login-corner-right.svg');
     background-position: right bottom;
@@ -35,6 +34,7 @@
   }
 
   &__form {
+    margin: auto;
     width: 70%;
   }
 


### PR DESCRIPTION
- Se aumento la opacidad de los inputs del login
- Se cambio la manera en que se centraba el formulario, ya que con `align-items: center` se veía mal en landscape en dispositivos muy pequeños, como el Iphone 5/SE. Pantallas aún más pequeñas igual se verían mal, pero no creo que valga la pena cambiar para esos casos

Antes:
![image](https://user-images.githubusercontent.com/12057523/49158946-1d307800-f302-11e8-8e78-0f5571cec0bc.png)

Ahora:
![image](https://user-images.githubusercontent.com/12057523/49158976-320d0b80-f302-11e8-991c-7f06d1489c76.png)
