### PR TITLE
fix(measure-sync-service): don't throw exception on invalid

### DIFF
--- a/app/services/measures_sync_service.rb
+++ b/app/services/measures_sync_service.rb
@@ -39,7 +39,7 @@ class MeasuresSyncService < PowerTypes::Service.new
   def create_or_find_measure(device, measure_data)
     measure = Measure.find_by(w_id: measure_data[:id])
     unless measure.present?
-      device.measures.create!(
+      device.measures.create(
         w_id: measure_data[:id],
         measured_at: measure_data[:timestamp].to_time,
         avg_age: measure_data[:average_age].to_f,


### PR DESCRIPTION
Se usa la versión sin signo de exclamación de create, para que la `measure` no se guarde en vez de levantar una excepción. Esto fue necesario ya que las mediciones vienen de una api, y hay algunos datos de prueba con valores inválidos que rompían la sincronización