### PR TITLE
fix(group-date-selector): set default in component, not in store

### DIFF
--- a/app/javascript/store/index.js
+++ b/app/javascript/store/index.js
@@ -35,7 +35,7 @@ export default new Vuex.Store({
     chartEndDate: null,
     chartInitialStartDate: null,
     chartInitialEndDate: null,
-    groupBy: getURLQueryParam('group_by') || 'day',
+    groupBy: getURLQueryParam('group_by'),
   },
   getters: {
     filtersQueryString(state) {

--- a/app/javascript/tools/chart.vue
+++ b/app/javascript/tools/chart.vue
@@ -15,7 +15,7 @@ export default {
   },
   computed: {
     groupBy() {
-      return this.$store.state.groupBy;
+      return this.$store.state.groupBy || 'day';
     },
     minRange() {
       // eslint-disable-next-line no-magic-numbers

--- a/app/javascript/tools/group-date-selector.vue
+++ b/app/javascript/tools/group-date-selector.vue
@@ -22,7 +22,7 @@ export default {
   computed: {
     groupBy: {
       get() {
-        return this.$store.state.groupBy;
+        return this.$store.state.groupBy || 'day';
       },
       set(grouping) {
         if (grouping) {


### PR DESCRIPTION
Como se seteaba para `groupBy` el default directamente en el state del store, cuando se llegaba a la vista de días por default (sin mostrar `group_by=day` en la URL del _browser_), se agregaba `group_by=day` al _getter_ `finalQueryString`. Esto provocaba que el botón para aplicar filtro creyera que había habido un cambio y se mostraba habilitado.
Para corregir esto, se setea el default a nivel de componente. En la imagen se muestra el botón "Aplicar" deshabilitado cuando se tiene el default de día tras el cambio:

![image](https://user-images.githubusercontent.com/12057523/50485032-537d1800-09d2-11e9-9f6e-9990a638db6e.png)
